### PR TITLE
Fixed failed test with MessageId vs uint64 assertion

### DIFF
--- a/storage/message_set_test.go
+++ b/storage/message_set_test.go
@@ -19,6 +19,6 @@ func TestMessageSetAlign(t *testing.T) {
 	assert.Equal(t, MessageId(6), set.entries[0].Id)
 	assert.Equal(t, MessageId(7), set.entries[1].Id)
 
-	assert.Equal(t, MessageId(6), byteOrder.Uint64(set.buffer[set.entries[0].Offset+INDEX_ID:]))
-	assert.Equal(t, MessageId(7), byteOrder.Uint64(set.buffer[set.entries[1].Offset+INDEX_ID:]))
+	assert.Equal(t, MessageId(6), MessageId(byteOrder.Uint64(set.buffer[set.entries[0].Offset+INDEX_ID:])))
+	assert.Equal(t, MessageId(7), MessageId(byteOrder.Uint64(set.buffer[set.entries[1].Offset+INDEX_ID:])))
 }


### PR DESCRIPTION
It seems that Assertion can't be done even though MessageId is a
wrapped uint64
